### PR TITLE
chore: pass variables/operationName into fetch

### DIFF
--- a/tests/gqltest.js
+++ b/tests/gqltest.js
@@ -91,10 +91,10 @@ function deployAndRun(dirname, tests) {
     return deployEndpoint(endpoint, dirname);
   });
 
-  tests.forEach(({ label, query, expected, authType }) => {
+  tests.forEach(({ label, query, variables, operationName, expected, authType }) => {
     it(label, function () {
       this.timeout(4000); // Occasional requests take > 2s
-      return runGqlOk(authType, endpoint, query).then(function (response) {
+      return runGqlOk(authType, endpoint, query, variables, operationName).then(function (response) {
         expectData(response, expected);
       });
     });


### PR DESCRIPTION
Allows test cases to use variables and/or operation name in requests