### PR TITLE
chore: fix check for no errors

### DIFF
--- a/tests/gqltest.js
+++ b/tests/gqltest.js
@@ -76,8 +76,10 @@ function runGqlOk(authType, endpoint, query, variables, operationName) {
       return result;
     })
     .then(function (result) {
-      response = result.json();
-      expect(response.errors).to.be.undefined;
+      return result.json();
+    })
+    .then(function (response) {
+      expect(response.errors, `no errors should exist: ${JSON.stringify(response.errors)}`).to.be.undefined;
       return response;
     });
 }


### PR DESCRIPTION
Check for no errors was incorrect as it was checking a promise, not the JSON response.

Ensure the expect reports the value of `errors`.

Tested manually with an error:
```
     AssertionError: no errors should exist: [{"message":"Cannot query field \"chuman\" on type \"Query\". Did you mean \"human\"?","locations":[{"line":2,"column":3}]}]: expected [ { …(2) } ] to be undefined
 
```