### PR TITLE
routing: add JSONata example

### DIFF
--- a/routing/supplies/README.md
+++ b/routing/supplies/README.md
@@ -32,7 +32,7 @@ It is supplied by three fields, each with a condition.
 > **Note**
 > Implementation of the fields (`@rest`) have been omitted for brevity.
 
-The script `src` must be ECMAScript 5.1 of JSONata and the field's arguments
+The script `src` must be ECMAScript 5.1 or JSONata and the field's arguments
 are available as global variables.
 
 If the returned value is `true` (ECMAScript `ToBoolean` conversion) then

--- a/routing/supplies/README.md
+++ b/routing/supplies/README.md
@@ -19,18 +19,20 @@ expected(id:ID):Delivery
 ```
 which given a tracking identifier returns when a package is expected.
 
-It is supplied by two fields, each with a condition.
+It is supplied by three fields, each with a condition.
 
 ```graphql
   fp(id: ID!): FastPackage
     @supplies(query: "expected" if: { src: "id.startsWith('FP-')" })
   ros(id: ID!): RainOrShine
     @supplies(query: "expected", if: { src: "id.startsWith('ROS-')" })
+  tyd(id: ID!): ToYourDoor
+    @supplies(query: "expected" if: {src: "$contains(id, /^TYD-/)", language: JSONATA})
 ```
 > **Note**
 > Implementation of the fields (`@rest`) have been omitted for brevity.
 
-The script `src` must be ECMAScript 5.1 and the field's arguments
+The script `src` must be ECMAScript 5.1 of JSONata and the field's arguments
 are available as global variables.
 
 If the returned value is `true` (ECMAScript `ToBoolean` conversion) then
@@ -38,7 +40,7 @@ the field is invoked, otherwise its value is `null`.
 
 Thus in this example if the tracking identifier starts with `FP-` a call
 is made to the FastPackage REST api, if it starts with `ROS-` a call to
-the `RainOrShine` REST api is called, otherwise no call is made.
+the `RainOrShine` REST api is called, `TYD-` a call to the To Your Door API otherwise no call is made.
 
 > **Note**
 > The supplying fields can have any implementation, FastPackage could
@@ -52,5 +54,6 @@ stepzen deploy
 
 stepzen request -f operations.graphql --var id='FP-123'
 stepzen request -f operations.graphql --var id='ROS-456'
+stepzen request -f operations.graphql --var id='TYD-234'
 stepzen request -f operations.graphql --var id='OTH-789'
 ```

--- a/routing/supplies/index.graphql
+++ b/routing/supplies/index.graphql
@@ -24,6 +24,14 @@ type RainOrShine implements Delivery {
   weather: String
 }
 
+"""
+Delivery by ToYourDoor.
+"""
+type ToYourDoor implements Delivery {
+  when: Date
+  note: String
+}
+
 type Query {
   """
   expected is the "supplied" field that returns an abstract
@@ -64,6 +72,27 @@ type Query {
             when: '2023-09-01',
             note: `Package ${get('id')} is on its way`,
             weather: 'dry and sunny',
+        }
+      }
+      """
+    )
+
+  """
+  tyd supplies Query.expected but only if the tracking identifier starts with `TYD-`.
+  A JSONata expression is used as the routing condition.
+  """
+  tyd(id: ID!): ToYourDoor
+    @supplies(
+      query: "expected"
+      if: {src: "$contains(id, /^TYD-/)", language: JSONATA}
+    )
+    @rest(
+      endpoint: "stepzen:empty"
+      ecmascript: """
+      function transformREST() {
+        return {
+            when: '2023-09-04',
+            note: `Package ${get('id')} is heading your way`,
         }
       }
       """

--- a/routing/supplies/tests/Test.js
+++ b/routing/supplies/tests/Test.js
@@ -40,7 +40,19 @@ describe(testDescription, function () {
       authType: authTypes.adminKey,
     },
     {
-      label: "neither",
+      label: "tyd",
+      query: requests,
+      variables: { id: "TYD-789" },
+      expected: {
+        expected: {
+          when: "2023-09-04",
+          note: "Package TYD-789 is heading your way",
+        },
+      },
+      authType: authTypes.adminKey,
+    },
+    {
+      label: "none",
       query: requests,
       variables: { id: "OTH-789" },
       expected: {


### PR DESCRIPTION
Now JSONata is supported, enhance the routing snippet with an additional supplying field.