### PR TITLE
chore: rename to operations.graphql to be consistent

### DIFF
--- a/dbquery/pagination/README.md
+++ b/dbquery/pagination/README.md
@@ -40,3 +40,27 @@ To retrieve the first page of a result, the operation is called with `after` omi
 Subsequent pages can then be retrieved by setting `after` to the value of `endCursor` from `pageInfo` from the previous request. `first` should be set to the value used in the first request.
 
 This is continued until `hasNextPage` is `false`.
+
+## Try it out!
+
+Deploy the schema from `dbquery/pagination` relative to the repository's root directory:
+
+```
+stepzen deploy
+```
+
+Run the [sample operations](operations.graphql):
+
+Fetch the first five records:
+
+```
+stepzen request -f operations.graphql --operation-name=Customers --var first=5
+```
+
+Fetch the next five, the value of `after` is taken from the `endCursor` field of the previous request:
+
+```
+stepzen request -f operations.graphql --operation-name=Customers --var first=5 --var after="eyJjIjoiTDpRdWVyeTpjdXN0b21lcnMiLCJvIjo0fQ=="
+```
+
+

--- a/dbquery/pagination/operations.graphql
+++ b/dbquery/pagination/operations.graphql
@@ -1,5 +1,5 @@
 # Page through customers from a database connection based pagination
-query CustomersConnectionBased($first: Int!, $after: String = "") {    
+query Customers($first: Int!, $after: String = "") {    
   customers(first: $first, after: $after) {
     edges {
       node {

--- a/dbquery/pagination/tests/Test.js
+++ b/dbquery/pagination/tests/Test.js
@@ -8,7 +8,7 @@ const {
 
 testDescription = getTestDescription("snippets", __dirname);
 
-const requestsFile = path.join(path.dirname(__dirname), "requests.graphql");
+const requestsFile = path.join(path.dirname(__dirname), "operations.graphql");
 const requests = fs.readFileSync(requestsFile, "utf8").toString();
 
 describe(testDescription, function () {
@@ -18,7 +18,7 @@ describe(testDescription, function () {
     {
       label: "first set of results",
       query: requests,
-      operationName: "CustomersConnectionBased",
+      operationName: "Customers",
       variables: { 
         first: 2 
       },
@@ -49,7 +49,7 @@ describe(testDescription, function () {
     {
       label: "next set of results",
       query: requests,
-      operationName: "CustomersConnectionBased",
+      operationName: "Customers",
       variables: {
         first: 2,
         after: CURSOR


### PR DESCRIPTION
Rename to be consistent and correct since the file contains operations.

Add examples to the README of how to easily run requests.