### PR TITLE
chore: use auth settings from gqltest

### DIFF
--- a/dbquery/pagination/tests/Test.js
+++ b/dbquery/pagination/tests/Test.js
@@ -77,5 +77,5 @@ describe(testDescription, function () {
       },
     },
   ];
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/dbquery/pagination/tests/Test.js
+++ b/dbquery/pagination/tests/Test.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("node:path");
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -44,7 +44,6 @@ describe(testDescription, function () {
           }
         }
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "next set of results",
@@ -76,8 +75,7 @@ describe(testDescription, function () {
           }
         }
       },
-      authType: authTypes.adminKey,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/dbquery/pings/postgresql/tests/Test.js
+++ b/dbquery/pings/postgresql/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../../tests/gqltest.js");
 

--- a/executable/persisted/tests/Test.js
+++ b/executable/persisted/tests/Test.js
@@ -3,7 +3,7 @@ const path = require("node:path");
 
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -27,7 +27,6 @@ describe(testDescription, function () {
           name: "Tromp",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "CustomerName",
@@ -42,7 +41,6 @@ describe(testDescription, function () {
           email: "marciaschinner@kub.io",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "Customer",
@@ -64,8 +62,7 @@ describe(testDescription, function () {
           },
         },
       },
-      authType: authTypes.adminKey,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests,stepzen.admin());
 });

--- a/executable/persisted/tests/Test.js
+++ b/executable/persisted/tests/Test.js
@@ -64,5 +64,5 @@ describe(testDescription, function () {
       },
     },
   ];
-  return deployAndRun(__dirname, tests,stepzen.admin());
+  return deployAndRun(__dirname, tests,stepzen.admin);
 });

--- a/materializer/nestedfieldselection/tests/Test.js
+++ b/materializer/nestedfieldselection/tests/Test.js
@@ -26,5 +26,5 @@ describe(testDescription, function () {
         },
     },
   ]
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/materializer/nestedfieldselection/tests/Test.js
+++ b/materializer/nestedfieldselection/tests/Test.js
@@ -1,6 +1,6 @@
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -24,8 +24,7 @@ describe(testDescription, function () {
             }
           }
         },
-      authType: authTypes.adminKey,
     },
   ]
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/protection/makeAllPublic/tests/Test.js
+++ b/protection/makeAllPublic/tests/Test.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("node:path");
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -27,7 +27,6 @@ describe(testDescription, function () {
           city: "Miami",
         },
       },
-      authType: authTypes.noAuth,
     },
     {
       label: "customer-2",
@@ -42,8 +41,7 @@ describe(testDescription, function () {
           city: "Santa Clara",
         },
       },
-      authType: authTypes.noAuth,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.public());
 });

--- a/protection/makeSomePublic/tests/Test.js
+++ b/protection/makeSomePublic/tests/Test.js
@@ -33,5 +33,5 @@ describe(testDescription, function () {
       },
     },
   ];
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/protection/makeSomePublic/tests/Test.js
+++ b/protection/makeSomePublic/tests/Test.js
@@ -1,6 +1,6 @@
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -14,7 +14,6 @@ describe(testDescription, function () {
       expected: {
         customer: { name: "John Doe", city: "Miami" },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "customer(2)",
@@ -22,7 +21,6 @@ describe(testDescription, function () {
       expected: {
         customer: { name: "Jane Smith", city: "Santa Clara" },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "customers",
@@ -33,8 +31,7 @@ describe(testDescription, function () {
           { name: "Jane Smith", city: "Santa Clara" },
         ],
       },
-      authType: authTypes.adminKey,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/reshape/fields/tests/Test.js
+++ b/reshape/fields/tests/Test.js
@@ -115,5 +115,5 @@ describe(testDescription, function () {
       },
     },
   ];
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/reshape/fields/tests/Test.js
+++ b/reshape/fields/tests/Test.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("node:path");
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -22,7 +22,6 @@ describe(testDescription, function () {
           name: "Leia Organa",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "person",
@@ -33,7 +32,6 @@ describe(testDescription, function () {
           name: "Han Solo",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "defaultHero",
@@ -44,7 +42,6 @@ describe(testDescription, function () {
           name: "R2-D2",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "luke",
@@ -55,7 +52,6 @@ describe(testDescription, function () {
           name: "Luke Skywalker",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "robot",
@@ -66,7 +62,6 @@ describe(testDescription, function () {
           name: "C-3PO",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "robotDefault",
@@ -77,7 +72,6 @@ describe(testDescription, function () {
           name: "R2-D2",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "humanName",
@@ -86,7 +80,6 @@ describe(testDescription, function () {
       expected: {
         humanName: "Leia Organa",
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "droidFriends",
@@ -112,7 +105,6 @@ describe(testDescription, function () {
           },
         ],
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "humanFriendsNames",
@@ -121,8 +113,7 @@ describe(testDescription, function () {
       expected: {
         humanFriendsNames: ["C-3PO", "Han Solo", "Luke Skywalker", "R2-D2"],
       },
-      authType: authTypes.adminKey,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/reshape/subset/tests/Test.js
+++ b/reshape/subset/tests/Test.js
@@ -30,5 +30,5 @@ describe(testDescription, function () {
       expected: { version: { __typename: "Version" } },
     },
   ];
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/reshape/subset/tests/Test.js
+++ b/reshape/subset/tests/Test.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("node:path");
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -23,14 +23,12 @@ describe(testDescription, function () {
           appearsIn: ["NEWHOPE", "EMPIRE", "JEDI"],
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "version",
       query: "{version { __typename}}",
       expected: { version: { __typename: "Version" } },
-      authType: authTypes.adminKey,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/rest/morecomplexpost/tests/Test.js
+++ b/rest/morecomplexpost/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 

--- a/rest/pagination/tests/Test.js
+++ b/rest/pagination/tests/Test.js
@@ -101,5 +101,5 @@ describe(testDescription, function () {
       },
     },
   ];
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/rest/pagination/tests/Test.js
+++ b/rest/pagination/tests/Test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require("node:path");
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -42,7 +42,6 @@ describe(testDescription, function () {
           },
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "customerPageNumber-11-20",
@@ -63,7 +62,6 @@ describe(testDescription, function () {
           },
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "customerPageNumber-21-23",
@@ -84,7 +82,6 @@ describe(testDescription, function () {
           },
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "firstCustomer",
@@ -93,7 +90,6 @@ describe(testDescription, function () {
       expected: {
         firstCustomer: generateNodes(1, 1)[0].node,
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "firstNCustomers",
@@ -103,8 +99,7 @@ describe(testDescription, function () {
       expected: {
         nCustomers: generateNodes(1, 5).map(edge => edge.node),
       },
-      authType: authTypes.adminKey,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/rest/postbody/tests/Test.js
+++ b/rest/postbody/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 

--- a/rest/restWithConfigYaml/tests/Test.js
+++ b/rest/restWithConfigYaml/tests/Test.js
@@ -14,5 +14,5 @@ describe(testDescription, function () {
         expected: {rest: {args: {q: ["Joe Smith", "Jane Smith"],},url: "https://httpbingo.org/get?apikey=56hdlks45reghunq&q=Joe+Smith&q=Jane+Smith",},},
       },
     ]
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/rest/restWithConfigYaml/tests/Test.js
+++ b/rest/restWithConfigYaml/tests/Test.js
@@ -1,6 +1,6 @@
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -12,8 +12,7 @@ describe(testDescription, function () {
       { label: "restquerywithconfig(q)", 
         query: '{rest(q: ["Joe Smith", "Jane Smith"])  { args { q } url } }', 
         expected: {rest: {args: {q: ["Joe Smith", "Jane Smith"],},url: "https://httpbingo.org/get?apikey=56hdlks45reghunq&q=Joe+Smith&q=Jane+Smith",},},
-        authType: authTypes.adminKey,
       },
     ]
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/rest/restWithParameters/tests/Test.js
+++ b/rest/restWithParameters/tests/Test.js
@@ -1,6 +1,6 @@
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -11,18 +11,15 @@ describe(testDescription, function () {
     { label: "restquery(q,v)", 
       query: '{restquery(q: ["Joe Smith", "Jane Smith"] v:"New York")  { args { q v } url } }', 
       expected: {restquery: {args: {q: ["Joe Smith", "Jane Smith"],v: ["New York"],},url: "https://httpbingo.org/get?q=Joe+Smith&q=Jane+Smith&v=New+York",},},
-      authType: authTypes.adminKey,
     },
     { label: "restquery(v)",
       query:  '{restquery(v:"New York")  { args { q v } url } }',
       expected: {restquery: {args: {q: null,v: ["New York"],}, url: "https://httpbingo.org/get?v=New+York",},},
-      authType: authTypes.adminKey,
     },
     { label: "restquery(q)",
       query:  '{restquery(q:["Mike Jones", "Sally Jones"])  { args { q v } url } }',
       expected: {restquery: {args: {q: ["Mike Jones", "Sally Jones"],v: null,}, url: "https://httpbingo.org/get?q=Mike+Jones&q=Sally+Jones",},},
-      authType: authTypes.adminKey,
     },
   ]
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/rest/restWithParameters/tests/Test.js
+++ b/rest/restWithParameters/tests/Test.js
@@ -21,5 +21,5 @@ describe(testDescription, function () {
       expected: {restquery: {args: {q: ["Mike Jones", "Sally Jones"],v: null,}, url: "https://httpbingo.org/get?q=Mike+Jones&q=Sally+Jones",},},
     },
   ]
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/routing/rerank/tests/Test.js
+++ b/routing/rerank/tests/Test.js
@@ -171,5 +171,5 @@ describe(testDescription, function () {
       },
     },
   ];
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/routing/rerank/tests/Test.js
+++ b/routing/rerank/tests/Test.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("node:path");
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -48,7 +48,6 @@ describe(testDescription, function () {
           ],
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "desc",
@@ -73,7 +72,6 @@ describe(testDescription, function () {
           ],
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "noop",
@@ -106,7 +104,6 @@ describe(testDescription, function () {
           ],
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "nothing",
@@ -116,7 +113,6 @@ describe(testDescription, function () {
       expected: {
         createAndSort: null,
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "reRank field",
@@ -173,8 +169,7 @@ describe(testDescription, function () {
           ],
         },
       },
-      authType: authTypes.adminKey,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/routing/supplies/tests/Test.js
+++ b/routing/supplies/tests/Test.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("node:path");
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -24,7 +24,6 @@ describe(testDescription, function () {
           distance: 17,
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "rain-or-shine",
@@ -37,7 +36,6 @@ describe(testDescription, function () {
           weather: "dry and sunny",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "tyd",
@@ -49,7 +47,6 @@ describe(testDescription, function () {
           note: "Package TYD-789 is heading your way",
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: "none",
@@ -58,8 +55,7 @@ describe(testDescription, function () {
       expected: {
         expected: null,
       },
-      authType: authTypes.adminKey,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/routing/supplies/tests/Test.js
+++ b/routing/supplies/tests/Test.js
@@ -57,5 +57,5 @@ describe(testDescription, function () {
       },
     },
   ];
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/sequence/arguments/tests/Test.js
+++ b/sequence/arguments/tests/Test.js
@@ -1,6 +1,6 @@
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 
@@ -11,19 +11,16 @@ describe(testDescription, function () {
     { label: "customer(1)", 
       query: '{customer(id:1){name city weather{temp}}}', 
       expected: {customer: { name: "John Doe", city: "Miami", weather: { temp: 100.0, }}},
-      authType: authTypes.adminKey,
     },
     { label: "customer(2)",
       query: '{customer(id:2){name city weather{temp}}}',
       expected:  {customer: {name: "Jane Smith", city: "Santa Clara", weather: {temp: 60.4, },},},
-      authType: authTypes.adminKey,
     },
     { label: "customer(1) metric, customer(2) metric",
       query: '{customer1: customer(id: "1") {city name weather(units: "metric") {temp}} customer2: customer(id: "2") {city name weather(units: "metric") {temp}}}',
       expected:   {customer1: {city: "Miami", name: "John Doe", weather: {temp: 37.77777777777778}},
                  customer2: {city: "Santa Clara", name: "Jane Smith", weather: {temp: 15.777777777777779}}},
-      authType: authTypes.adminKey,
   },    
   ]
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });

--- a/sequence/arguments/tests/Test.js
+++ b/sequence/arguments/tests/Test.js
@@ -22,5 +22,5 @@ describe(testDescription, function () {
                  customer2: {city: "Santa Clara", name: "Jane Smith", weather: {temp: 15.777777777777779}}},
   },    
   ]
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/sequence/forLoops/tests/Test.js
+++ b/sequence/forLoops/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 

--- a/sequence/transformsInMaterializer/tests/Test.js
+++ b/sequence/transformsInMaterializer/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 

--- a/sequence/useOfJSON/tests/Test.js
+++ b/sequence/useOfJSON/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "chain": "^0.2.1",
         "dotenv": "^16.0.3",
-        "gqltest": "stepzen-dev/gqltest#cf5a6d21ac4693bd82ae5d2d71447be7900d33a9",
+        "gqltest": "stepzen-dev/gqltest#f951b93474db0a02798a1b9e00d54e252db4ca89",
         "mocha": "^10.0.0"
       }
     },
@@ -476,8 +476,8 @@
     "node_modules/gqltest": {
       "name": "stepzen-dev-gqltest",
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/stepzen-dev/gqltest.git#cf5a6d21ac4693bd82ae5d2d71447be7900d33a9",
-      "integrity": "sha512-CYgCh4Vcxixcl7Zagjpr3NCDzNIXRnBbCKJItAn5TghrXHYRXCHzuQ8kOfuwjtdIK25ENJfL+kNZRMzFbF0uag==",
+      "resolved": "git+ssh://git@github.com/stepzen-dev/gqltest.git#f951b93474db0a02798a1b9e00d54e252db4ca89",
+      "integrity": "sha512-0imX7wKC4e1QC6OgH+uMMbAhhHSSTvp5pfzssDo4opKdpSNZEdYkHJ9/m8DX02fqAbtZXvcjWRlQuTqT0luxhA==",
       "dependencies": {
         "chai": "4.3.6",
         "chai-graphql": "^4.0.0",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "chain": "^0.2.1",
         "dotenv": "^16.0.3",
-        "gqltest": "stepzen-dev/gqltest#73d21c2e15975416c2c5ce5ea33a4675cab823e1",
+        "gqltest": "stepzen-dev/gqltest#cf5a6d21ac4693bd82ae5d2d71447be7900d33a9",
         "mocha": "^10.0.0"
       }
     },
@@ -295,11 +295,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -309,11 +309,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/decamelize": {
       "version": "4.0.0",
@@ -481,8 +476,8 @@
     "node_modules/gqltest": {
       "name": "stepzen-dev-gqltest",
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/stepzen-dev/gqltest.git#73d21c2e15975416c2c5ce5ea33a4675cab823e1",
-      "integrity": "sha512-i+XiMYMyWUJE+3WdEifMPpBblEjHy0qLOBRUGazmd5LfcznpTaXNvn7+OVrggmdWawzuYmH+wf30UXEa9oVB4Q==",
+      "resolved": "git+ssh://git@github.com/stepzen-dev/gqltest.git#cf5a6d21ac4693bd82ae5d2d71447be7900d33a9",
+      "integrity": "sha512-CYgCh4Vcxixcl7Zagjpr3NCDzNIXRnBbCKJItAn5TghrXHYRXCHzuQ8kOfuwjtdIK25ENJfL+kNZRMzFbF0uag==",
       "dependencies": {
         "chai": "4.3.6",
         "chai-graphql": "^4.0.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,7 @@
     "chain": "^0.2.1",
     "dotenv": "^16.0.3",
     "mocha": "^10.0.0",
-    "gqltest": "stepzen-dev/gqltest#cf5a6d21ac4693bd82ae5d2d71447be7900d33a9"
+    "gqltest": "stepzen-dev/gqltest#f951b93474db0a02798a1b9e00d54e252db4ca89"
   },
   "keywords": [],
   "author": ""

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,7 @@
     "chain": "^0.2.1",
     "dotenv": "^16.0.3",
     "mocha": "^10.0.0",
-    "gqltest": "stepzen-dev/gqltest#73d21c2e15975416c2c5ce5ea33a4675cab823e1"
+    "gqltest": "stepzen-dev/gqltest#cf5a6d21ac4693bd82ae5d2d71447be7900d33a9"
   },
   "keywords": [],
   "author": ""

--- a/transforms/combineIntoString/tests/Test.js
+++ b/transforms/combineIntoString/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 

--- a/transforms/filter/tests/Test.js
+++ b/transforms/filter/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 

--- a/transforms/jsonarrayToJsonobject/tests/Test.js
+++ b/transforms/jsonarrayToJsonobject/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 

--- a/transforms/jsonobjectToJsonarray/tests/Test.js
+++ b/transforms/jsonobjectToJsonarray/tests/Test.js
@@ -1,6 +1,5 @@
 const {
   deployAndRun,
-  authTypes,
   getTestDescription,
 } = require("../../../tests/gqltest.js");
 

--- a/unions/errorsAsData/tests/Test.js
+++ b/unions/errorsAsData/tests/Test.js
@@ -30,5 +30,5 @@ describe(testDescription, function () {
       },
     },
   ];
-  return deployAndRun(__dirname, tests, stepzen.admin());
+  return deployAndRun(__dirname, tests, stepzen.admin);
 });

--- a/unions/errorsAsData/tests/Test.js
+++ b/unions/errorsAsData/tests/Test.js
@@ -1,6 +1,6 @@
 const {
   deployAndRun,
-  authTypes,
+  stepzen,
   getTestDescription,
 } = require('../../../tests/gqltest.js');
 
@@ -18,7 +18,6 @@ describe(testDescription, function () {
           token: '1234567890',
         },
       },
-      authType: authTypes.adminKey,
     },
     {
       label: 'auth(incorrect)',
@@ -29,8 +28,7 @@ describe(testDescription, function () {
           message: 'Invalid credentials',
         },
       },
-      authType: authTypes.adminKey,
     },
   ];
-  return deployAndRun(__dirname, tests);
+  return deployAndRun(__dirname, tests, stepzen.admin());
 });


### PR DESCRIPTION
- Removes the auth types and uses the stepzen capabilities in `gqltest`, such as `stepzen.admin` to get headers for a StepZen admin key request.
- Changes the snippets test to pass the auth type once per run, instead of once per test.

Note some existing missing newlines, we should run prettier on all .js/.graphql files (but separate PRs to this).