### PR TITLE
chore: use gqltest.runtests

### DIFF
--- a/tests/gqltest.js
+++ b/tests/gqltest.js
@@ -4,11 +4,10 @@ const { URL } = require("url");
 const path = require("node:path");
 
 const {
-  executeOK,
-  logOnFail,
-} = require('gqltest/packages/gqltest/gqltest.js')
+  runtests,
+} = require('gqltest/packages/gqltest/gqltest.js');
 
-const stepzen = require('gqltest/packages/gqltest/stepzen.js');
+const stepzen = require("gqltest/packages/gqltest/stepzen.js");
 
 const endpoint = process.env.STEPZEN_ENDPOINT;
 
@@ -31,58 +30,23 @@ function deployEndpoint(endpoint, dirname) {
   console.log(stdout);
 }
 
-// Runs a GraphQL request against the endpoint
-// as a test returning the response.
-// The test will fail if the request does not
-// have status 200 or has any GraphQL errors.
-async function runGqlOk(endpoint, headers, request, expected) {
- await executeOK({
-    test: this,
-    endpoint,
-    headers: headers,
-    request,
-    expected,
-  })
-}
-
 // deploys graphql schema located in dirname to the test endpoint provided by the environment (process.env.STEPZEN_ENDPOINT),
 // and then runs through all fo the field selection tests.
 function deployAndRun(dirname, tests, headers) {
-  it("deploy", function () {
-    // deployEndpoint will try up to three times to deploy
-    // the schema with a backoff that can total four seconds.
-    // So set the timeout to be (3*10)+4 seconds to cover a worst case scenario.
-    this.timeout(34000);
-    return deployEndpoint(endpoint, dirname);
-  });
+  describe("deployAndRun", function () {
+    this.timeout(10000);
+    this.slow(1000);
+    it("deploy", function () {
+      // deployEndpoint will try up to three times to deploy
+      // the schema with a backoff that can total four seconds.
+      // So set the timeout to be (3*10)+4 seconds to cover a worst case scenario.
+      this.timeout(34000);
+      this.slow(5000);
+      return deployEndpoint(endpoint, dirname);
+    });
 
-  afterEach('log-failure', logOnFail)
-  tests.forEach(
-    ({ label, documentId, query, variables, operationName, expected, authType }) => {
-      it(label, async function () {
-        this.timeout(4000); // Occasional requests take > 2s
-        let request = {}
-        if (query) {
-          request.query = query;
-        }
-        if (documentId) {
-          request.documentId = documentId;
-        }
-        if (operationName) {
-          request.operationName = operationName;
-        }
-        if (variables) {
-          request.variables = variables;
-        }
-        return await runGqlOk(
-          endpoint,
-          headers,
-          request,
-          expected,
-        );
-      });
-    }
-  );
+    runtests("run", endpoint, headers, tests);
+  });
 }
 
 function getTestDescription(testRoot, fullDirName) {
@@ -96,4 +60,4 @@ function getTestDescription(testRoot, fullDirName) {
 exports.deployAndRun = deployAndRun;
 exports.getTestDescription = getTestDescription;
 
-exports.stepzen = stepzen
+exports.stepzen = stepzen;

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "chain": "^0.2.1",
         "dotenv": "^16.0.3",
-        "gqltest": "stepzen-dev/gqltest#f951b93474db0a02798a1b9e00d54e252db4ca89",
+        "gqltest": "stepzen-dev/gqltest#v0.1",
         "mocha": "^10.0.0"
       }
     },
@@ -476,8 +476,7 @@
     "node_modules/gqltest": {
       "name": "stepzen-dev-gqltest",
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/stepzen-dev/gqltest.git#f951b93474db0a02798a1b9e00d54e252db4ca89",
-      "integrity": "sha512-0imX7wKC4e1QC6OgH+uMMbAhhHSSTvp5pfzssDo4opKdpSNZEdYkHJ9/m8DX02fqAbtZXvcjWRlQuTqT0luxhA==",
+      "resolved": "git+ssh://git@github.com/stepzen-dev/gqltest.git#2d58ba8993213ec2abbf6aa669a88f8231122f68",
       "dependencies": {
         "chai": "4.3.6",
         "chai-graphql": "^4.0.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,7 @@
     "chain": "^0.2.1",
     "dotenv": "^16.0.3",
     "mocha": "^10.0.0",
-    "gqltest": "stepzen-dev/gqltest#f951b93474db0a02798a1b9e00d54e252db4ca89"
+    "gqltest": "stepzen-dev/gqltest#v0.1"
   },
   "keywords": [],
   "author": ""


### PR DESCRIPTION
- Switches to gqltest v0.1
- which has `gqltest.runtests` taking a list of objects to run the tests.
- Update snippets' `gqltest.js` to use `runtests`.