### PR TITLE
fix: update postgresql references to new aws rds

### DIFF
--- a/dbquery/custom-query/config.yaml
+++ b/dbquery/custom-query/config.yaml
@@ -1,4 +1,4 @@
 configurationset:
   - configuration:
       name: postgresql_config
-      uri: postgresql://postgresql.introspection.stepzen.net/introspection?user=testUserIntrospection&password=HurricaneStartingSample1934
+      uri: postgresql://postgresqlaws.introspection.stepzen.net/introspection?user=testUserIntrospection&password=HurricaneStartingSample1934

--- a/dbquery/pagination/config.yaml
+++ b/dbquery/pagination/config.yaml
@@ -1,4 +1,4 @@
 configurationset:
   - configuration:
       name: postgresql_config
-      uri: postgresql://postgresql.introspection.stepzen.net/introspection?user=testUserIntrospection&password=HurricaneStartingSample1934
+      uri: postgresql://postgresqlaws.introspection.stepzen.net/introspection?user=testUserIntrospection&password=HurricaneStartingSample1934

--- a/protection/jwt-claims-dbquery/config.yaml
+++ b/protection/jwt-claims-dbquery/config.yaml
@@ -18,4 +18,4 @@ access:
 configurationset:
   - configuration:
       name: postgresql_config
-      uri: postgresql://postgresql.introspection.stepzen.net/introspection?user=testUserIntrospection&password=HurricaneStartingSample1934
+      uri: postgresql://postgresqlaws.introspection.stepzen.net/introspection?user=testUserIntrospection&password=HurricaneStartingSample1934

--- a/protection/jwt-claims/config.yaml
+++ b/protection/jwt-claims/config.yaml
@@ -18,4 +18,4 @@ access:
 configurationset:
   - configuration:
       name: postgresql_config
-      uri: postgresql://postgresql.introspection.stepzen.net/introspection?user=testUserIntrospection&password=HurricaneStartingSample1934
+      uri: postgresql://postgresqlaws.introspection.stepzen.net/introspection?user=testUserIntrospection&password=HurricaneStartingSample1934


### PR DESCRIPTION
This PR updates the PostgreSQL reference (postgresql.introspection.stepzen.net) to the new AWS RDS (postgresqlaws.introspection.stepzen.net) as part of the GCP decommissioning effort.