### PR TITLE
chore: add totalEdges for Postgres snippet

### DIFF
--- a/dbquery/pagination/api.graphql
+++ b/dbquery/pagination/api.graphql
@@ -26,6 +26,11 @@ the starting point).
 type CustomerConnection {
   edges: [CustomerEdge]
   pageInfo: PageInfo!
+
+  """
+  Total number of edges, may be `null` if the value cannot be determined.
+  """
+  totalEdges: Int
 }
 
 """

--- a/dbquery/pagination/api.graphql
+++ b/dbquery/pagination/api.graphql
@@ -28,7 +28,7 @@ type CustomerConnection {
   pageInfo: PageInfo!
 
   """
-  Total number of edges, may be `null` if the value cannot be determined.
+  Total number of edges, will be `null` if the value cannot be determined.
   """
   totalEdges: Int
 }

--- a/dbquery/pagination/operations.graphql
+++ b/dbquery/pagination/operations.graphql
@@ -11,5 +11,6 @@ query Customers($first: Int!, $after: String = "") {
       endCursor
       hasNextPage
     }
+    totalEdges
   }
 }

--- a/dbquery/pagination/tests/Test.js
+++ b/dbquery/pagination/tests/Test.js
@@ -41,7 +41,8 @@ describe(testDescription, function () {
           pageInfo: {
             hasNextPage: true,
             endCursor: CURSOR
-          }
+          },
+          totalEdges: 10
         }
       },
     },
@@ -72,7 +73,8 @@ describe(testDescription, function () {
           pageInfo: {
             endCursor: "eyJjIjoiTDpRdWVyeTpjdXN0b21lcnMiLCJvIjozfQ==",
             hasNextPage: true
-          }
+          },
+          totalEdges: 10
         }
       },
     },


### PR DESCRIPTION
`totalEdges:Int` is supported in APIC-GraphQL connection objects, and will be set to the total number of edges in the connection (after any filtering).

If the value cannot be determined then it will select as `null`.